### PR TITLE
public/private

### DIFF
--- a/EgammaAnalysis/ElectronTools/interface/EnergyScaleCorrection_class.hh
+++ b/EgammaAnalysis/ElectronTools/interface/EnergyScaleCorrection_class.hh
@@ -130,7 +130,8 @@ typedef std::map < correctionCategory_class, correctionValue_class > correction_
 //============================== Main class
 class EnergyScaleCorrection_class
 {
-  
+	
+public:  
   enum fileFormat_t {
     UNKNOWN=0,
     GLOBE,
@@ -145,7 +146,6 @@ class EnergyScaleCorrection_class
         kNParamSmear
   };
   
-public:
   bool doScale, doSmearings;
   
 public:


### PR DESCRIPTION
- the struct paramSmear_t is used in public method, and therefore should be public.
- idem fileFormat_t
